### PR TITLE
Feature/promo box

### DIFF
--- a/SBBDesignSystemMobileSwiftUI/Views/SBBPromotionBox.swift
+++ b/SBBDesignSystemMobileSwiftUI/Views/SBBPromotionBox.swift
@@ -131,14 +131,14 @@ public struct SBBPromotionBox: View {
                                     .accessibilityAction {
                                         self.isPresented = false
                                     }
-                                    .accessibility(label: Text("\(newIn == nil ? "new".localized : (String.localizedStringWithFormat(NSLocalizedString("new in %@", tableName: nil, bundle: Helper.bundle, value: "", comment: ""), newIn!))) . ") + title + Text(closeAccessibility))
+                                    .accessibility(label: Text("\(newIn == nil ? "new".localized : (String.localizedStringWithFormat(NSLocalizedString("new in %@", tableName: nil, bundle: Helper.bundle, value: "", comment: ""), newIn!))) . ") + title + Text(". \(closeAccessibility)"))
                                 bottomView
                                     .accessibilityElement(children: .combine)
                                     .accessibilityAddTraits(.isButton)
                                     .accessibilityAction {
                                         onClick()
                                     }
-                                    .accessibility(label: text + Text(clickAccessibility))
+                                    .accessibility(label: text + Text(" \(clickAccessibility)"))
                             }
                         } else {
                             VStack(alignment: .leading, spacing: 8) {
@@ -146,7 +146,7 @@ public struct SBBPromotionBox: View {
                                 bottomView
                             }
                             .accessibilityElement(children: .combine)
-                            .accessibility(label: Text("\(newIn == nil ? "new".localized : (String.localizedStringWithFormat(NSLocalizedString("new in %@", tableName: nil, bundle: Helper.bundle, value: "", comment: ""), newIn!))) . ") + title + text + Text(closeAccessibility))
+                            .accessibility(label: Text("\(newIn == nil ? "new".localized : (String.localizedStringWithFormat(NSLocalizedString("new in %@", tableName: nil, bundle: Helper.bundle, value: "", comment: ""), newIn!))) . ") + title + Text(" ") + text + Text(" \(closeAccessibility)"))
                             .accessibilityAddTraits(.isButton)
                             .accessibilityAction {
                                 self.isPresented = false

--- a/SBBDesignSystemMobileSwiftUI/Views/SBBPromotionBox.swift
+++ b/SBBDesignSystemMobileSwiftUI/Views/SBBPromotionBox.swift
@@ -131,14 +131,14 @@ public struct SBBPromotionBox: View {
                                     .accessibilityAction {
                                         self.isPresented = false
                                     }
-                                    .accessibility(label: Text("\(newIn == nil ? "new".localized : (String.localizedStringWithFormat(NSLocalizedString("new in %@", tableName: nil, bundle: Helper.bundle, value: "", comment: ""), newIn!))) . ") + title + Text(" . ") + Text(closeAccessibility))
+                                    .accessibility(label: Text("\(newIn == nil ? "new".localized : (String.localizedStringWithFormat(NSLocalizedString("new in %@", tableName: nil, bundle: Helper.bundle, value: "", comment: ""), newIn!))) . ") + title + Text(" . \(closeAccessibility)"))
                                 bottomView
                                     .accessibilityElement(children: .combine)
                                     .accessibilityAddTraits(.isButton)
                                     .accessibilityAction {
                                         onClick()
                                     }
-                                    .accessibility(label: text + Text(" . ") + Text(clickAccessibility))
+                                    .accessibility(label: text + Text(" . \(clickAccessibility)"))
                             }
                         } else {
                             VStack(alignment: .leading, spacing: 8) {
@@ -146,7 +146,7 @@ public struct SBBPromotionBox: View {
                                 bottomView
                             }
                             .accessibilityElement(children: .combine)
-                            .accessibility(label: Text("\(newIn == nil ? "new".localized : (String.localizedStringWithFormat(NSLocalizedString("new in %@", tableName: nil, bundle: Helper.bundle, value: "", comment: ""), newIn!))) . ") + title + Text(" . ") + text + Text(" . ") + Text(closeAccessibility))
+                            .accessibility(label: Text("\(newIn == nil ? "new".localized : (String.localizedStringWithFormat(NSLocalizedString("new in %@", tableName: nil, bundle: Helper.bundle, value: "", comment: ""), newIn!))) . ") + title + Text(" . ") + text + Text(" . \(closeAccessibility)"))
                             .accessibilityAddTraits(.isButton)
                             .accessibilityAction {
                                 self.isPresented = false

--- a/SBBDesignSystemMobileSwiftUI/Views/SBBPromotionBox.swift
+++ b/SBBDesignSystemMobileSwiftUI/Views/SBBPromotionBox.swift
@@ -131,14 +131,14 @@ public struct SBBPromotionBox: View {
                                     .accessibilityAction {
                                         self.isPresented = false
                                     }
-                                    .accessibility(label: Text("\(newIn == nil ? "new".localized : (String.localizedStringWithFormat(NSLocalizedString("new in %@", tableName: nil, bundle: Helper.bundle, value: "", comment: ""), newIn!))) . ") + title + Text(" . \(closeAccessibility)"))
+                                    .accessibility(label: Text("\(newIn == nil ? "new".localized : (String.localizedStringWithFormat(NSLocalizedString("new in %@", tableName: nil, bundle: Helper.bundle, value: "", comment: ""), newIn!))) . ") + title + Text(closeAccessibility))
                                 bottomView
                                     .accessibilityElement(children: .combine)
                                     .accessibilityAddTraits(.isButton)
                                     .accessibilityAction {
                                         onClick()
                                     }
-                                    .accessibility(label: text + Text(" . \(clickAccessibility)"))
+                                    .accessibility(label: text + Text(clickAccessibility))
                             }
                         } else {
                             VStack(alignment: .leading, spacing: 8) {
@@ -146,7 +146,7 @@ public struct SBBPromotionBox: View {
                                 bottomView
                             }
                             .accessibilityElement(children: .combine)
-                            .accessibility(label: Text("\(newIn == nil ? "new".localized : (String.localizedStringWithFormat(NSLocalizedString("new in %@", tableName: nil, bundle: Helper.bundle, value: "", comment: ""), newIn!))) . ") + title + Text(" . ") + text + Text(" . \(closeAccessibility)"))
+                            .accessibility(label: Text("\(newIn == nil ? "new".localized : (String.localizedStringWithFormat(NSLocalizedString("new in %@", tableName: nil, bundle: Helper.bundle, value: "", comment: ""), newIn!))) . ") + title + text + Text(closeAccessibility))
                             .accessibilityAddTraits(.isButton)
                             .accessibilityAction {
                                 self.isPresented = false

--- a/SBBDesignSystemMobileSwiftUIDemo/Views/DetailViews/PromotionBoxDemo.swift
+++ b/SBBDesignSystemMobileSwiftUIDemo/Views/DetailViews/PromotionBoxDemo.swift
@@ -16,7 +16,7 @@ struct PromotionBoxDemo: View {
     var body: some View {
         VStack(spacing: 8) {
             ScrollView(showsIndicators: false) {
-                SBBPromotionBox(newIn: "l'application", title: Text("Title"), text: Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque vulputate massa ut ex fringilla, vel rutrum nulla pretium. Vivamus auctor ex sed nunc maximus."), isPresented: $isPresented1)
+                SBBPromotionBox(title: Text("Title"), text: Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque vulputate massa ut ex fringilla, vel rutrum nulla pretium. Vivamus auctor ex sed nunc maximus."), isPresented: $isPresented1)
                 
                 if !isPresented1 {
                     HStack {
@@ -31,7 +31,7 @@ struct PromotionBoxDemo: View {
                     }
                 }
                 
-                SBBPromotionBox(newIn: "l'application", title: Text("Title"), text: Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque vulputate massa ut ex fringilla, vel rutrum nulla pretium. Vivamus auctor ex sed nunc maximus."), isPresented: $isPresented2, onClick: {
+                SBBPromotionBox(title: Text("Title"), text: Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque vulputate massa ut ex fringilla, vel rutrum nulla pretium. Vivamus auctor ex sed nunc maximus."), isPresented: $isPresented2, onClick: {
                     self.showAlert = true
                 })
                 


### PR DESCRIPTION
Accessibility: we want the title / text / infos to be separated in the VoiceOver, so that it makes a small pause in between each of them. 
Current bug: the voiceover says the title, text, then add says 'point' and finally reads the info. The point should not be read, it should simply make the VoiceOver pause.